### PR TITLE
chore: remove describe import from gameValidation test

### DIFF
--- a/__tests__/gameValidation.test.ts
+++ b/__tests__/gameValidation.test.ts
@@ -1,5 +1,4 @@
 import { parseLocalDateTime, validateCreateGame } from '@/src/utils/gameValidation';
-import {describe} from "node:test";
 
 describe('gameValidation', () => {
   test('parseLocalDateTime accepts ISO', () => {


### PR DESCRIPTION
## Summary
- rely on Jest's global describe in gameValidation tests

## Testing
- `TZ=America/New_York npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68af32599f648320b09099033fb7182a