### PR TITLE
Validate date component ranges

### DIFF
--- a/__tests__/gameValidation.test.ts
+++ b/__tests__/gameValidation.test.ts
@@ -17,6 +17,15 @@ describe('gameValidation', () => {
     expect(d).toBeNull();
   });
 
+  test('parseLocalDateTime rejects out-of-range values', () => {
+    expect(parseLocalDateTime('2020-13-10T10:00')).toBeNull(); // month
+    expect(parseLocalDateTime('2020-00-10T10:00')).toBeNull(); // month
+    expect(parseLocalDateTime('2021-02-29T10:00')).toBeNull(); // day
+    expect(parseLocalDateTime('2020-01-32T10:00')).toBeNull(); // day
+    expect(parseLocalDateTime('2020-01-10T24:00')).toBeNull(); // hour
+    expect(parseLocalDateTime('2020-01-10T10:60')).toBeNull(); // minute
+  });
+
   // These tests assume the process timezone is set to a zone with DST,
   // e.g. run with `TZ=America/New_York`.
   describe('parseLocalDateTime DST edge cases', () => {

--- a/src/utils/gameValidation.ts
+++ b/src/utils/gameValidation.ts
@@ -1,13 +1,42 @@
 export function parseLocalDateTime(input: string): Date | null {
   if (!input) return null;
-  // Accept ISO or "YYYY-MM-DDTHH:mm"
-  const iso = Date.parse(input);
-  if (!Number.isNaN(iso)) return new Date(iso);
-  const m = input.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})$/);
+  // Accept ISO (UTC) or "YYYY-MM-DDTHH:mm" (local)
+  let m = input.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(\.\d+)?)?Z$/);
+  if (m) {
+    const [_, y, mo, d, h, mi, s] = m;
+    const year = Number(y);
+    const month = Number(mo);
+    const day = Number(d);
+    const hour = Number(h);
+    const minute = Number(mi);
+    const second = Number(s ?? '0');
+
+    if (month < 1 || month > 12) return null;
+    if (hour < 0 || hour > 23) return null;
+    if (minute < 0 || minute > 59) return null;
+    if (second < 0 || second > 59) return null;
+    const maxDay = new Date(year, month, 0).getDate();
+    if (day < 1 || day > maxDay) return null;
+
+    return new Date(Date.UTC(year, month - 1, day, hour, minute, second, 0));
+  }
+
+  m = input.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})$/);
   if (!m) return null;
   const [_, y, mo, d, h, mi] = m;
-  const dt = new Date(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), 0, 0);
-  return Number.isNaN(dt.getTime()) ? null : dt;
+  const year = Number(y);
+  const month = Number(mo);
+  const day = Number(d);
+  const hour = Number(h);
+  const minute = Number(mi);
+
+  if (month < 1 || month > 12) return null;
+  if (hour < 0 || hour > 23) return null;
+  if (minute < 0 || minute > 59) return null;
+  const maxDay = new Date(year, month, 0).getDate();
+  if (day < 1 || day > maxDay) return null;
+
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
 }
 
 export function validateCreateGame(fields: { title: string; startsAt: string; maxPlayers?: string }) {


### PR DESCRIPTION
## Summary
- Add range checks for month, day, hour, minute (and seconds) before constructing dates
- Reject invalid date parts in `parseLocalDateTime`
- Test invalid month/day/hour/minute cases

## Testing
- `TZ=America/New_York npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68af325c55fc8320bad9b81872c5030f