### PR TITLE
Mock Date.now in game validation test

### DIFF
--- a/__tests__/gameValidation.test.ts
+++ b/__tests__/gameValidation.test.ts
@@ -35,6 +35,9 @@ describe('gameValidation', () => {
   });
 
   test('validateCreateGame requires title and future date', () => {
+    const fixedNow = new Date('2030-01-01T00:00:00Z').getTime();
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+
     const past = new Date(Date.now() - 60_000).toISOString();
     const { errors: e1, valid: v1 } = validateCreateGame({ title: '', startsAt: past, maxPlayers: '' });
     expect(v1).toBe(false);
@@ -46,6 +49,8 @@ describe('gameValidation', () => {
     expect(v2).toBe(true);
     expect(e2.title).toBeUndefined();
     expect(e2.startsAt).toBeUndefined();
+
+    nowSpy.mockRestore();
   });
 
   test('validateCreateGame validates positive maxPlayers', () => {


### PR DESCRIPTION
## Summary
- stabilize game validation tests by mocking `Date.now` to a fixed point in time

## Testing
- `TZ=America/New_York npx jest __tests__/gameValidation.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68af325f9c188320a2f2716a76067080