### PR TITLE
Refetch data when connection restored

### DIFF
--- a/app/(tabs)/game/[id].tsx
+++ b/app/(tabs)/game/[id].tsx
@@ -25,7 +25,7 @@ import { useParticipants } from '@/src/features/games/hooks/useParticipants';
 import { createInvite, deleteGame, joinGame, leaveGame } from '@/src/features/games/api';
 import { useAuthStore } from '@/src/stores/auth';
 import { confirm } from '@/src/components/ConfirmDialog';
-import { useOnline } from '@/src/components/OfflineBanner';
+import { useOnline, onOnline } from '@/src/components/OfflineBanner';
 
 export default function GameDetailsScreen() {
   const { id, autojoin } = useLocalSearchParams<{ id?: string; autojoin?: string }>();
@@ -71,6 +71,17 @@ export default function GameDetailsScreen() {
   };
 
   const toast = useToast();
+
+  useEffect(() => {
+    const unsub = onOnline(async () => {
+      await Promise.all([
+        refetch(),
+        qc.refetchQueries({ queryKey: ['game', id, 'participants'] }),
+      ]);
+      toast.success('Updated');
+    });
+    return unsub;
+  }, [refetch, qc, id, toast]);
 
   const openOwnerMenu = () => {
     if (!id) return;

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -2,11 +2,36 @@ import React, { useEffect, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { Text, View } from '@/components/Themed';
 
+type OnlineListener = () => void;
+const onlineListeners = new Set<OnlineListener>();
+
+export function onOnline(listener: OnlineListener): () => void {
+  onlineListeners.add(listener);
+  return () => onlineListeners.delete(listener);
+}
+
+function emitOnline() {
+  onlineListeners.forEach((l) => {
+    try {
+      l();
+    } catch {
+      // Ignore listener errors
+    }
+  });
+}
+
 export function useOnline() {
   const [online, setOnline] = useState(true);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
+
+    const update = (next: boolean) => {
+      setOnline((prev) => {
+        if (!prev && next) emitOnline();
+        return next;
+      });
+    };
 
     // Try optional NetInfo without triggering Metro static resolution
     const modName = '@react-native-community/netinfo';
@@ -21,12 +46,12 @@ export function useOnline() {
 
     if (NetInfo?.addEventListener) {
       const sub = NetInfo.addEventListener((state: any) => {
-        setOnline(!!state?.isConnected && !!state?.isInternetReachable);
+        update(!!state?.isConnected && !!state?.isInternetReachable);
       });
       unsubscribe = () => sub && sub();
     } else if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
       // Web fallback
-      const handler = () => setOnline((navigator as any).onLine !== false);
+      const handler = () => update((navigator as any).onLine !== false);
       handler();
       window.addEventListener('online', handler);
       window.addEventListener('offline', handler);
@@ -36,7 +61,7 @@ export function useOnline() {
       };
     } else {
       // No detection available; assume online to avoid blocking UX
-      setOnline(true);
+      update(true);
     }
 
     return () => {

--- a/src/features/games/components/GamesList.tsx
+++ b/src/features/games/components/GamesList.tsx
@@ -15,7 +15,7 @@ import { joinGame, leaveGame } from '@/src/features/games/api';
 import type { Game } from '@/src/features/games/types';
 import { usePrefs } from '@/src/stores/prefs';
 import { useDebouncedValue } from '@/src/hooks/useDebouncedValue';
-import { useOnline } from '@/src/components/OfflineBanner';
+import { useOnline, onOnline } from '@/src/components/OfflineBanner';
 import { useInfiniteGames } from '@/src/features/games/hooks/useInfiniteGames';
 import { useAuthStore } from '@/src/stores/auth';
 
@@ -241,6 +241,15 @@ export default function GamesList({ initialShowJoined = false, allowToggle = tru
   });
   const { join, leave, joinPendingId, leavePendingId } = useJoinLeaveOptimistic();
   const online = useOnline();
+  const toast = useToast();
+
+  useEffect(() => {
+    const unsub = onOnline(async () => {
+      await refetch();
+      toast.success('Updated');
+    });
+    return unsub;
+  }, [refetch, toast]);
 
   // Keep prefs in sync (after hydration)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- emit a global `onOnline` event when network status becomes reachable
- refresh GamesList and GameDetails queries on reconnect and show an "Updated" toast

## Testing
- `CI=1 npm test` *(fails: Duplicate declaration "parseLocalDateTime")*


------
https://chatgpt.com/codex/tasks/task_e_68af407a39848320afa077d8e671c63a