### PR TITLE
Add exponential backoff retry to game queries

### DIFF
--- a/src/features/games/hooks/useGame.ts
+++ b/src/features/games/hooks/useGame.ts
@@ -1,10 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchGame } from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
 
 export function useGame(id: string | undefined) {
   return useQuery({
     queryKey: ['game', id],
     queryFn: () => fetchGame(id as string),
     enabled: !!id,
+    retry: queryRetry,
   });
 }

--- a/src/features/games/hooks/useGames.ts
+++ b/src/features/games/hooks/useGames.ts
@@ -1,9 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchGames } from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
 
 export function useGames() {
   return useQuery({
     queryKey: ['games'],
     queryFn: fetchGames,
+    retry: queryRetry,
   });
 }

--- a/src/features/games/hooks/useParticipants.ts
+++ b/src/features/games/hooks/useParticipants.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchParticipants } from '../api';
 import type { Participant } from '../types';
+import { queryRetry } from '@/src/utils/queryRetry';
 
 export function useParticipants(gameId: string | undefined) {
   return useQuery<Participant[]>({
     queryKey: ['game', gameId, 'participants'],
     queryFn: () => fetchParticipants(gameId as string),
     enabled: !!gameId,
+    retry: queryRetry,
   });
 }

--- a/src/utils/queryRetry.ts
+++ b/src/utils/queryRetry.ts
@@ -1,0 +1,11 @@
+export function queryRetry(failureCount: number) {
+  if (failureCount >= 3) {
+    return false;
+  }
+
+  const delay = Math.min(1000 * 2 ** (failureCount - 1), 30_000);
+
+  return new Promise<boolean>((resolve) => {
+    setTimeout(() => resolve(true), delay);
+  });
+}


### PR DESCRIPTION
## Summary
- add `queryRetry` utility for exponential backoff retries
- use `queryRetry` with `useGame`, `useGames`, and `useParticipants`

## Testing
- `npm test -- --watchAll=false` *(fails: TypeError: Duplicate declaration "parseLocalDateTime")*


------
https://chatgpt.com/codex/tasks/task_e_68af407b87588320b886880f08c9203d