### PR TITLE
Add accessibility labels to toolbar icons

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -30,7 +30,7 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <TabBarIcon name="list" color={color} />,
           headerRight: () => (
             <Link href="/modal" asChild>
-              <Pressable>
+              <Pressable accessibilityLabel="About" accessibilityRole="link">
                 {({ pressed }) => (
                   <FontAwesome
                     name="info-circle"

--- a/app/(tabs)/game/[id].tsx
+++ b/app/(tabs)/game/[id].tsx
@@ -211,7 +211,12 @@ export default function GameDetailsScreen() {
           title: data.title || 'Game',
           headerRight: () => (
             <RNView style={{ flexDirection: 'row', gap: 16, paddingRight: 8 }}>
-              <Pressable onPress={onShare} style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })} accessibilityLabel="Share">
+              <Pressable
+                onPress={onShare}
+                style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                accessibilityLabel="Share"
+                accessibilityRole="button"
+              >
                 <FontAwesome name="share-alt" size={20} />
               </Pressable>
               <Pressable
@@ -222,6 +227,7 @@ export default function GameDetailsScreen() {
                 }}
                 style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
                 accessibilityLabel="Copy link"
+                accessibilityRole="button"
               >
                 <FontAwesome name="link" size={20} />
               </Pressable>
@@ -229,6 +235,7 @@ export default function GameDetailsScreen() {
                 onPress={() => router.push(`/(tabs)/game/${id}/qr`)}
                 style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
                 accessibilityLabel="Show QR code"
+                accessibilityRole="button"
               >
                 <FontAwesome name="qrcode" size={20} />
               </Pressable>
@@ -250,6 +257,7 @@ export default function GameDetailsScreen() {
                 }}
                 style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
                 accessibilityLabel="Invite players"
+                accessibilityRole="button"
               >
                 <FontAwesome name="user-plus" size={20} />
               </Pressable>

--- a/src/features/games/components/GamesList.tsx
+++ b/src/features/games/components/GamesList.tsx
@@ -170,6 +170,7 @@ function GameCard({
         <Link href={`/(tabs)/game/${game.id}`} asChild>
           <Pressable
             accessibilityLabel={`Open ${game.title}`}
+            accessibilityRole="link"
             style={({ pressed }) => [{ opacity: pressed ? 0.7 : 1.0, flex: 1 }]}
           >
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
@@ -182,6 +183,7 @@ function GameCard({
         </Link>
         <Pressable
           accessibilityLabel="Share game"
+          accessibilityRole="button"
           hitSlop={10}
           onPress={share}
           onLongPress={copyLink}
@@ -360,6 +362,7 @@ export default function GamesList({ initialShowJoined = false, allowToggle = tru
             }}
             style={({ pressed }) => [{ alignSelf: 'flex-start', backgroundColor: '#e5e7eb', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 20, opacity: pressed ? 0.7 : 1 }]}
             accessibilityLabel="Clear filters"
+            accessibilityRole="button"
           >
             <Text>Clear filters ✕</Text>
           </Pressable>


### PR DESCRIPTION
## Summary
- add accessibility labels and roles to toolbar buttons

## Testing
- `CI=true npm test` *(fails: Duplicate declaration "parseLocalDateTime")*


------
https://chatgpt.com/codex/tasks/task_e_68af407c811c83209250b18272e247b9