### PR TITLE
Improve chip contrast for status indicators

### DIFF
--- a/app/(tabs)/game/[id].tsx
+++ b/app/(tabs)/game/[id].tsx
@@ -270,7 +270,7 @@ export default function GameDetailsScreen() {
 
       {isError ? (
         <View style={{ backgroundColor: '#fee2e2', padding: 8, borderRadius: 6, marginBottom: 8 }}>
-          <Text style={{ color: '#991b1b', marginBottom: 4 }}>There was a problem updating this game.</Text>
+          <Text style={{ color: '#7f1d1d', marginBottom: 4 }}>There was a problem updating this game.</Text>
           <Button title={isRefetching ? 'Retrying…' : 'Retry'} onPress={() => refetch()} />
         </View>
       ) : null}
@@ -285,13 +285,13 @@ export default function GameDetailsScreen() {
           const left = Math.max(data.maxPlayers - data.playersCount, 0);
           const low = left <= 2;
           const fullText = left === 0 ? 'Full' : left === 1 ? '1 slot left' : `${left} slots left`;
-          const color = left === 0 ? '#991b1b' : low ? '#92400e' : '#374151';
+          const color = left === 0 ? '#7f1d1d' : low ? '#7c2d12' : '#374151';
           return <Text style={{ color }}>{fullText}</Text>;
         })()
       ) : null}
       {isFull ? (
         <View style={{ backgroundColor: '#fee2e2', padding: 8, borderRadius: 6, marginTop: 6 }}>
-          <Text style={{ color: '#991b1b' }}>This game is full. You can still open it to see details.</Text>
+          <Text style={{ color: '#7f1d1d' }}>This game is full. You can still open it to see details.</Text>
         </View>
       ) : null}
       {data.description ? (
@@ -395,7 +395,7 @@ function ParticipantsSection({ gameId }: { gameId: string }) {
 
       {isError ? (
         <View style={{ backgroundColor: '#fee2e2', padding: 8, borderRadius: 6, marginBottom: 8 }}>
-          <Text style={{ color: '#991b1b', marginBottom: 4 }}>{(error as any)?.message ?? 'Failed to load participants.'}</Text>
+          <Text style={{ color: '#7f1d1d', marginBottom: 4 }}>{(error as any)?.message ?? 'Failed to load participants.'}</Text>
           <Button title={isRefetching ? 'Retrying…' : 'Retry'} onPress={() => refetch()} />
         </View>
       ) : null}

--- a/src/features/games/components/GamesList.tsx
+++ b/src/features/games/components/GamesList.tsx
@@ -102,10 +102,18 @@ function useJoinLeaveOptimistic() {
   return { join, leave, joinPendingId, leavePendingId };
 }
 
-function Chip({ text, color = '#e5e7eb' }: { text: string; color?: string }) {
+function Chip({
+  text,
+  color = '#e5e7eb',
+  textColor = '#374151',
+}: {
+  text: string;
+  color?: string;
+  textColor?: string;
+}) {
   return (
     <View style={{ backgroundColor: color, paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10, marginLeft: 8 }}>
-      <Text style={{ fontSize: 12 }}>{text}</Text>
+      <Text style={{ fontSize: 12, color: textColor }}>{text}</Text>
     </View>
   );
 }
@@ -174,9 +182,15 @@ function GameCard({
           >
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
               <Text style={styles.cardTitle} numberOfLines={1}>{game.title}</Text>
-              {joined ? <Chip text="Joined" color="#d1fae5" /> : null}
-              {isOwner ? <Chip text="Owner" color="#e0e7ff" /> : null}
-              {isFull ? <Chip text="Full" color="#fee2e2" /> : null}
+              {joined ? (
+                <Chip text="Joined" color="#d1fae5" textColor="#065f46" />
+              ) : null}
+              {isOwner ? (
+                <Chip text="Owner" color="#e0e7ff" textColor="#3730a3" />
+              ) : null}
+              {isFull ? (
+                <Chip text="Full" color="#fee2e2" textColor="#b91c1c" />
+              ) : null}
             </View>
           </Pressable>
         </Link>


### PR DESCRIPTION
## Summary
- ensure chip text color meets 4.5:1 contrast by using darker palette variants
- darken warning text on game detail screen for better readability

## Testing
- `npm test -- --watchAll=false` *(fails: Duplicate declaration "parseLocalDateTime")*

------
https://chatgpt.com/codex/tasks/task_e_68af407f003c8320bd46f8b7e8db03d2