### PR TITLE
Add link formatting utilities and tests

### DIFF
--- a/__tests__/gameValidation.test.ts
+++ b/__tests__/gameValidation.test.ts
@@ -1,11 +1,10 @@
-import {describe} from "node:test";
-import { parseLocalDateTime, validateCreateGame } from '@/src/utils/gameValidation';
+import type * as gv from '@/src/utils/gameValidation';
 
 const ORIGINAL_TZ = process.env.TZ;
 const OriginalDate = Date;
 
-let parseLocalDateTime: typeof import('@/src/utils/gameValidation').parseLocalDateTime;
-let validateCreateGame: typeof import('@/src/utils/gameValidation').validateCreateGame;
+let parseLocalDateTime: typeof gv.parseLocalDateTime;
+let validateCreateGame: typeof gv.validateCreateGame;
 
 function mockTimezone(tz: string) {
   const RealDate = OriginalDate;

--- a/__tests__/links.test.ts
+++ b/__tests__/links.test.ts
@@ -1,0 +1,44 @@
+import { formatCalendarLink, formatMapLink } from '@/src/utils/links';
+
+describe('formatCalendarLink', () => {
+  it('generates correct URL for US timezone', () => {
+    const url = formatCalendarLink({
+      title: 'Pickup Game',
+      start: new Date('2023-03-25T10:00:00-05:00'),
+      end: new Date('2023-03-25T12:00:00-05:00'),
+      location: '123 Main St, New York',
+    });
+    expect(url).toBe(
+      'https://calendar.google.com/calendar/render?action=TEMPLATE&text=Pickup+Game&dates=20230325T150000Z%2F20230325T170000Z&location=123+Main+St%2C+New+York',
+    );
+  });
+
+  it('generates correct URL for European timezone', () => {
+    const url = formatCalendarLink({
+      title: 'Match',
+      start: new Date('2023-06-01T10:00:00+02:00'),
+      end: new Date('2023-06-01T12:30:00+02:00'),
+      location: 'Berlin',
+    });
+    expect(url).toBe(
+      'https://calendar.google.com/calendar/render?action=TEMPLATE&text=Match&dates=20230601T080000Z%2F20230601T103000Z&location=Berlin',
+    );
+  });
+});
+
+describe('formatMapLink', () => {
+  it('encodes address string', () => {
+    const url = formatMapLink('123 Main St, Springfield');
+    expect(url).toBe(
+      'https://www.google.com/maps/search/?api=1&query=123%20Main%20St%2C%20Springfield',
+    );
+  });
+
+  it('encodes coordinates', () => {
+    const url = formatMapLink({ lat: 40.7128, lng: -74.006 });
+    expect(url).toBe(
+      'https://www.google.com/maps/search/?api=1&query=40.7128%2C-74.006',
+    );
+  });
+});
+

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,0 +1,40 @@
+export type CalendarEvent = {
+  title: string;
+  start: Date;
+  end: Date;
+  location?: string;
+  details?: string;
+};
+
+function formatDate(d: Date): string {
+  return d.toISOString().replace(/[-:]|\.\d{3}/g, '');
+}
+
+/**
+ * Build a Google Calendar event URL for an event.
+ * Dates are converted to UTC as required by the calendar URL format.
+ */
+export function formatCalendarLink(event: CalendarEvent): string {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${formatDate(event.start)}/${formatDate(event.end)}`,
+  });
+  if (event.details) params.set('details', event.details);
+  if (event.location) params.set('location', event.location);
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+/**
+ * Format a Google Maps link for a string address or lat/lng pair.
+ */
+export function formatMapLink(location: string | { lat: number; lng: number }): string {
+  let query: string;
+  if (typeof location === 'string') {
+    query = location;
+  } else {
+    query = `${location.lat},${location.lng}`;
+  }
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+}
+


### PR DESCRIPTION
## Summary
- add utility to format Google Calendar event links and map URLs
- cover calendar and map utilities with Jest tests across timezones and location inputs
- fix game validation tests to use type-only imports

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af4081919083208bec4a590291d432