### PR TITLE
Display games list refresh time and auto update

### DIFF
--- a/src/features/games/components/GamesList.tsx
+++ b/src/features/games/components/GamesList.tsx
@@ -235,7 +235,18 @@ export default function GamesList({ initialShowJoined = false, allowToggle = tru
     listRef.current?.scrollToOffset({ offset: 0, animated: true });
   }, [showJoined, timeFilter]);
 
-  const { data, isLoading, isError, error, refetch, isRefetching, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteGames({
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isRefetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    dataUpdatedAt,
+  } = useInfiniteGames({
     q: debouncedQuery || undefined,
     joined: showJoined || undefined,
   });
@@ -275,6 +286,18 @@ export default function GamesList({ initialShowJoined = false, allowToggle = tru
       [g.title, g.location, g.sport, g.description].some((v) => (v ?? '').toLowerCase().includes(q))
     );
   }, [all, showJoined, debouncedQuery, timeFilter]);
+
+  const updatedMinutesAgo = useMemo(() => {
+    if (!dataUpdatedAt) return 0;
+    return Math.floor((Date.now() - dataUpdatedAt) / 60000);
+  }, [dataUpdatedAt]);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      refetch();
+    }, 3 * 60 * 1000);
+    return () => clearInterval(t);
+  }, [refetch]);
 
   if (isLoading && !data) {
     return (
@@ -423,6 +446,11 @@ export default function GamesList({ initialShowJoined = false, allowToggle = tru
                     </RNView>
                     <Button title={isRefetching ? 'Retrying…' : 'Retry now'} onPress={() => refetch()} />
                   </RNView>
+                ) : null}
+                {!isLoading && !isRefetching ? (
+                  <Text style={{ marginTop: 4, color: '#6b7280' }}>
+                    Updated {updatedMinutesAgo} min ago
+                  </Text>
                 ) : null}
               </View>
             }

--- a/src/features/games/hooks/useGames.ts
+++ b/src/features/games/hooks/useGames.ts
@@ -2,8 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchGames } from '../api';
 
 export function useGames() {
-  return useQuery({
+  const { refetch, dataUpdatedAt, ...query } = useQuery({
     queryKey: ['games'],
     queryFn: fetchGames,
   });
+
+  return { ...query, refetch, dataUpdatedAt };
 }


### PR DESCRIPTION
## Summary
- expose `dataUpdatedAt` and refetch from `useGames`
- show "Updated X min ago" in games list header
- periodically refetch games list and support pull-to-refresh

## Testing
- `npm test -- --watchAll=false` *(fails: Duplicate declaration "parseLocalDateTime")*

------
https://chatgpt.com/codex/tasks/task_e_68af403859d8832080189daed108d859