### PR TITLE
feat(account): show field saved state

### DIFF
--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,21 +1,30 @@
 import React from 'react';
-import { StyleSheet, TextInput, TextInputProps } from 'react-native';
+import { StyleSheet, TextInput, TextInputProps, View as RNView } from 'react-native';
 import { Text, View } from '@/components/Themed';
 
 type Props = TextInputProps & {
   label?: string;
   error?: string | null;
+  rightElement?: React.ReactNode;
 };
 
-export default function FormField({ label, error, style, ...rest }: Props) {
+export default function FormField({ label, error, style, rightElement, ...rest }: Props) {
   return (
     <View style={styles.wrapper}>
       {label ? <Text style={styles.label}>{label}</Text> : null}
-      <TextInput
-        style={[styles.input, error ? styles.inputError : null, style]}
-        placeholderTextColor="#9ca3af"
-        {...rest}
-      />
+      <RNView style={styles.inputWrapper}>
+        <TextInput
+          style={[
+            styles.input,
+            error ? styles.inputError : null,
+            rightElement ? styles.inputWithAddon : null,
+            style,
+          ]}
+          placeholderTextColor="#9ca3af"
+          {...rest}
+        />
+        {rightElement ? <RNView style={styles.rightElement}>{rightElement}</RNView> : null}
+      </RNView>
       {error ? <Text style={styles.error}>{error}</Text> : null}
     </View>
   );
@@ -24,6 +33,7 @@ export default function FormField({ label, error, style, ...rest }: Props) {
 const styles = StyleSheet.create({
   wrapper: { marginBottom: 10 },
   label: { marginBottom: 6, fontWeight: '500' },
+  inputWrapper: { position: 'relative' },
   input: {
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: '#ccc',
@@ -34,6 +44,14 @@ const styles = StyleSheet.create({
   },
   inputError: {
     borderColor: '#ef4444',
+  },
+  inputWithAddon: { paddingRight: 28 },
+  rightElement: {
+    position: 'absolute',
+    right: 8,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
   },
   error: { color: '#ef4444', marginTop: 4 },
 });


### PR DESCRIPTION
## Summary
- track blur and saved state for display name and avatar URL fields
- show inline checkmark after field saves successfully
- extend FormField to support optional right-side elements

## Testing
- `npx jest --runInBand` *(fails: Duplicate declaration "parseLocalDateTime")*

------
https://chatgpt.com/codex/tasks/task_e_68af403efef48320b3c40c75a80274f4