### PR TITLE
Show share long press hint once

### DIFF
--- a/src/features/games/components/GamesList.tsx
+++ b/src/features/games/components/GamesList.tsx
@@ -1,5 +1,15 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Button, FlatList, Pressable, RefreshControl, Share, StyleSheet, TextInput, View as RNView } from 'react-native';
+import {
+  ActivityIndicator,
+  Button,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  Share,
+  StyleSheet,
+  TextInput,
+  View as RNView,
+} from 'react-native';
 import { Link } from 'expo-router';
 import * as Linking from 'expo-linking';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
@@ -10,10 +20,8 @@ import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query
 import { Text, View } from '@/components/Themed';
 import EmptyState from '@/src/components/EmptyState';
 import { SkeletonCard } from '@/src/components/Skeleton';
-import { useToast } from '@/src/components/ToastProvider';
 import { joinGame, leaveGame } from '@/src/features/games/api';
 import type { Game } from '@/src/features/games/types';
-import { usePrefs } from '@/src/stores/prefs';
 import { useDebouncedValue } from '@/src/hooks/useDebouncedValue';
 import { useOnline } from '@/src/components/OfflineBanner';
 import { useInfiniteGames } from '@/src/features/games/hooks/useInfiniteGames';
@@ -131,6 +139,7 @@ function GameCard({
   const isFull = !joined && typeof game.maxPlayers === 'number' && typeof game.playersCount === 'number' && game.playersCount >= game.maxPlayers;
 
   const toast = useToast();
+  const { shareHintShown, setShareHintShown } = usePrefs();
 
   const share = () => {
     const url = Linking.createURL(`/game/${game.id}`);
@@ -164,6 +173,15 @@ function GameCard({
     if (copied) toast.info('Link copied');
   };
 
+  const handleLongPress = async () => {
+    if (!shareHintShown) {
+      toast.info('Tip: Long‑press to copy link');
+      setShareHintShown(true);
+      return;
+    }
+    await copyLink();
+  };
+
   return (
     <View style={styles.card}>
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -184,7 +202,7 @@ function GameCard({
           accessibilityLabel="Share game"
           hitSlop={10}
           onPress={share}
-          onLongPress={copyLink}
+          onLongPress={handleLongPress}
           style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1, padding: 6 })}
         >
           <FontAwesome name="share-alt" size={18} />

--- a/src/stores/prefs.ts
+++ b/src/stores/prefs.ts
@@ -6,32 +6,49 @@ type PrefsState = {
   showJoinedDefault: boolean;
   timeFilter: 'all' | 'today' | 'week';
   defaultCalDuration: number; // minutes, e.g., 60/90/120
+  shareHintShown: boolean;
   setLastQuery: (q: string) => void;
   setShowJoinedDefault: (v: boolean) => void;
   setTimeFilter: (t: 'all' | 'today' | 'week') => void;
   setDefaultCalDuration: (m: number) => void;
+  setShareHintShown: (v: boolean) => void;
   _rehydrated?: boolean;
 };
 
 const KEY = 'prefs:v1';
 
-async function loadPrefs(): Promise<Pick<PrefsState, 'lastQuery' | 'showJoinedDefault' | 'timeFilter' | 'defaultCalDuration'>> {
+async function loadPrefs(): Promise<Pick<
+  PrefsState,
+  'lastQuery' | 'showJoinedDefault' | 'timeFilter' | 'defaultCalDuration' | 'shareHintShown'
+>> {
   try {
     const raw = await SecureStore.getItemAsync(KEY);
-    if (!raw) return { lastQuery: '', showJoinedDefault: false, timeFilter: 'all', defaultCalDuration: 60 };
+    if (!raw)
+      return { lastQuery: '', showJoinedDefault: false, timeFilter: 'all', defaultCalDuration: 60, shareHintShown: false };
     const parsed = JSON.parse(raw);
     return {
       lastQuery: typeof parsed.lastQuery === 'string' ? parsed.lastQuery : '',
       showJoinedDefault: !!parsed.showJoinedDefault,
       timeFilter: parsed.timeFilter === 'today' || parsed.timeFilter === 'week' ? parsed.timeFilter : 'all',
       defaultCalDuration: Number.isFinite(parsed.defaultCalDuration) ? parsed.defaultCalDuration : 60,
+      shareHintShown: !!parsed.shareHintShown,
     };
   } catch {
-    return { lastQuery: '', showJoinedDefault: false, timeFilter: 'all', defaultCalDuration: 60 };
+    return {
+      lastQuery: '',
+      showJoinedDefault: false,
+      timeFilter: 'all',
+      defaultCalDuration: 60,
+      shareHintShown: false,
+    };
   }
 }
 
-async function savePrefs(partial: Partial<Pick<PrefsState, 'lastQuery' | 'showJoinedDefault' | 'timeFilter' | 'defaultCalDuration'>>) {
+async function savePrefs(
+  partial: Partial<
+    Pick<PrefsState, 'lastQuery' | 'showJoinedDefault' | 'timeFilter' | 'defaultCalDuration' | 'shareHintShown'>
+  >,
+) {
   try {
     const raw = await SecureStore.getItemAsync(KEY);
     const base = raw ? JSON.parse(raw) : {};
@@ -54,6 +71,7 @@ export const usePrefs = create<PrefsState>((set, get) => {
     showJoinedDefault: false,
     timeFilter: 'all',
     defaultCalDuration: 60,
+    shareHintShown: false,
     setLastQuery: (q: string) => {
       set({ lastQuery: q });
       void savePrefs({ lastQuery: q });
@@ -69,6 +87,10 @@ export const usePrefs = create<PrefsState>((set, get) => {
     setDefaultCalDuration: (m) => {
       set({ defaultCalDuration: m });
       void savePrefs({ defaultCalDuration: m });
+    },
+    setShareHintShown: (v) => {
+      set({ shareHintShown: v });
+      void savePrefs({ shareHintShown: v });
     },
   };
 });


### PR DESCRIPTION
## Summary
- persist whether share hint has been shown in prefs
- show long-press share tooltip only on first long-press

## Testing
- `npm test` *(fails: Duplicate declaration "parseLocalDateTime")*

------
https://chatgpt.com/codex/tasks/task_e_68af407290848320b854c47ba066960b