### PR TITLE
feat: add auth sessions and MFA hooks

### DIFF
--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -1,5 +1,51 @@
 import { api, setTokens } from '@/src/api/client';
 
+export type AuthSession = {
+  id: string;
+  userAgent?: string;
+  createdAt?: string;
+  lastActiveAt?: string;
+  current?: boolean;
+};
+
+export async function refresh(body: { refreshToken?: string } = {}) {
+  const { data } = await api.post('/auth/refresh', body, { headers: { 'Cache-Control': 'no-store' } });
+  await setTokens({ accessToken: data.accessToken, refreshToken: data.refreshToken });
+  return data;
+}
+
+export async function verifyMfa(body: {
+  username: string;
+  code: string;
+  rememberDevice?: boolean;
+}) {
+  const { data } = await api.post('/auth/mfa/verify', body, { headers: { 'Cache-Control': 'no-store' } });
+  await setTokens({ accessToken: data.accessToken, refreshToken: data.refreshToken });
+  return data;
+}
+
+export async function enrollMfa(body: { code: string }) {
+  const { data } = await api.post('/auth/mfa/enroll', body, { headers: { 'Cache-Control': 'no-store' } });
+  return data;
+}
+
+export async function listSessions(): Promise<AuthSession[]> {
+  const { data } = await api.get('/auth/sessions', { headers: { 'Cache-Control': 'no-store' } });
+  return data;
+}
+
+export async function revokeSession(id: string): Promise<void> {
+  await api.delete(`/auth/sessions/${id}`, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function requestPasswordReset(usernameOrEmail: string): Promise<void> {
+  await api.post('/auth/forgot', { usernameOrEmail }, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function verifyPasswordReset(token: string, password: string): Promise<void> {
+  await api.post('/auth/reset', { token, password }, { headers: { 'Cache-Control': 'no-store' } });
+}
+
 export async function logout(): Promise<void> {
   try {
     await api.post('/auth/logout', null, { headers: { 'Cache-Control': 'no-store' } });

--- a/src/features/auth/hooks/useEnrollMfa.ts
+++ b/src/features/auth/hooks/useEnrollMfa.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { enrollMfa } from '@/src/features/auth/api';
+import { useAuthStore } from '@/src/stores/auth';
+
+export function useEnrollMfa() {
+  const setMfaEnabled = useAuthStore((s) => s.setMfaEnabled);
+
+  return useMutation({
+    mutationFn: (body: { code: string }) => enrollMfa(body),
+    onSuccess: () => {
+      setMfaEnabled(true);
+    },
+  });
+}

--- a/src/features/auth/hooks/useRefresh.ts
+++ b/src/features/auth/hooks/useRefresh.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { refresh } from '@/src/features/auth/api';
+import { api } from '@/src/api/client';
+import { useAuthStore } from '@/src/stores/auth';
+
+export function useRefresh() {
+  const setUser = useAuthStore((s) => s.setUser);
+
+  return useMutation({
+    mutationFn: async () => {
+      await refresh();
+      const { data } = await api.get('/auth/me', { headers: { 'Cache-Control': 'no-store' } });
+      return data;
+    },
+    onSuccess: (user) => {
+      setUser(user);
+    },
+  });
+}

--- a/src/features/auth/hooks/useRequestPasswordReset.ts
+++ b/src/features/auth/hooks/useRequestPasswordReset.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { requestPasswordReset } from '@/src/features/auth/api';
+
+export function useRequestPasswordReset() {
+  return useMutation({
+    mutationFn: (usernameOrEmail: string) => requestPasswordReset(usernameOrEmail),
+  });
+}

--- a/src/features/auth/hooks/useResetPassword.ts
+++ b/src/features/auth/hooks/useResetPassword.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { verifyPasswordReset } from '@/src/features/auth/api';
+
+export function useResetPassword() {
+  return useMutation({
+    mutationFn: ({ token, password }: { token: string; password: string }) =>
+      verifyPasswordReset(token, password),
+  });
+}

--- a/src/features/auth/hooks/useRevokeSession.ts
+++ b/src/features/auth/hooks/useRevokeSession.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { revokeSession } from '@/src/features/auth/api';
+import { useAuthStore } from '@/src/stores/auth';
+
+export function useRevokeSession() {
+  const sessions = useAuthStore((s) => s.sessions);
+  const setSessions = useAuthStore((s) => s.setSessions);
+
+  return useMutation({
+    mutationFn: (id: string) => revokeSession(id),
+    onSuccess: (_data, id) => {
+      setSessions(sessions.filter((s) => s.id !== id));
+    },
+  });
+}

--- a/src/features/auth/hooks/useSessions.ts
+++ b/src/features/auth/hooks/useSessions.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { listSessions } from '@/src/features/auth/api';
+import { useAuthStore } from '@/src/stores/auth';
+
+export function useSessions() {
+  const setSessions = useAuthStore((s) => s.setSessions);
+
+  return useQuery({
+    queryKey: ['sessions'],
+    queryFn: listSessions,
+    onSuccess: (sessions) => {
+      setSessions(sessions);
+    },
+  });
+}

--- a/src/features/auth/hooks/useVerifyMfa.ts
+++ b/src/features/auth/hooks/useVerifyMfa.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { verifyMfa } from '@/src/features/auth/api';
+import { api } from '@/src/api/client';
+import { useAuthStore } from '@/src/stores/auth';
+
+export function useVerifyMfa() {
+  const setUser = useAuthStore((s) => s.setUser);
+  const setMfaEnabled = useAuthStore((s) => s.setMfaEnabled);
+
+  return useMutation({
+    mutationFn: async (body: { username: string; code: string; rememberDevice?: boolean }) => {
+      await verifyMfa(body);
+      const { data } = await api.get('/auth/me', { headers: { 'Cache-Control': 'no-store' } });
+      return data;
+    },
+    onSuccess: (user) => {
+      setUser(user);
+      setMfaEnabled(true);
+    },
+  });
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import type { AuthSession } from '@/src/features/auth/api';
+
 export type AuthUser = {
   username: string;
   roles: string[];
@@ -9,12 +11,20 @@ export type AuthUser = {
 
 type AuthState = {
   user: AuthUser | null;
+  sessions: AuthSession[];
+  mfaEnabled: boolean;
   setUser: (u: AuthUser | null) => void;
+  setSessions: (s: AuthSession[]) => void;
+  setMfaEnabled: (v: boolean) => void;
   clear: () => void;
 };
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
+  sessions: [],
+  mfaEnabled: false,
   setUser: (u) => set({ user: u }),
-  clear: () => set({ user: null }),
+  setSessions: (s) => set({ sessions: s }),
+  setMfaEnabled: (v) => set({ mfaEnabled: v }),
+  clear: () => set({ user: null, sessions: [], mfaEnabled: false }),
 }));


### PR DESCRIPTION
## Summary
- add API wrappers for token refresh, MFA, session management and password reset
- create React Query hooks for refresh, MFA, session listing/revocation, and password reset
- extend auth store with session and MFA state

## Testing
- `npm test` *(fails: Playwright Test needs to be invoked separately)*
- `npm run lint` *(fails: ESLint couldn't find config "expo" )*
- `npx tsc --noEmit` *(fails: type errors in existing useParticipants.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68af840b9f688320958430070c95e031