### PR TITLE
Add ETag-aware profile endpoints and avatar management

### DIFF
--- a/src/features/user/api.ts
+++ b/src/features/user/api.ts
@@ -1,14 +1,24 @@
 import { api } from '@/src/api/client';
 import type { AuthUser } from '@/src/stores/auth';
 
-export async function getProfile(): Promise<AuthUser> {
-  const { data } = await api.get('/users/me', { headers: { 'Cache-Control': 'no-store' } });
-  return data as AuthUser;
+type ProfileResponse = { profile: AuthUser; etag?: string };
+
+export async function getProfile(): Promise<ProfileResponse> {
+  const { data, headers } = await api.get('/profiles/me', { headers: { 'Cache-Control': 'no-store' } });
+  return { profile: data as AuthUser, etag: headers['etag'] };
 }
 
-export async function updateProfile(input: Partial<Pick<AuthUser, 'displayName' | 'avatarUrl'>>): Promise<AuthUser> {
-  const { data } = await api.put('/users/me', input, { headers: { 'Cache-Control': 'no-store' } });
-  return data as AuthUser;
+export async function updateProfile(
+  input: Partial<Pick<AuthUser, 'displayName' | 'avatarUrl'>>,
+  etag?: string
+): Promise<ProfileResponse> {
+  const { data, headers } = await api.put('/profiles/me', input, {
+    headers: {
+      'Cache-Control': 'no-store',
+      ...(etag ? { 'If-Match': etag } : {}),
+    },
+  });
+  return { profile: data as AuthUser, etag: headers['etag'] };
 }
 
 export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
@@ -33,10 +43,15 @@ export async function resendVerificationEmail(): Promise<void> {
 }
 
 /**
- * Upload avatar image file and return absolute URL.
- * Backend endpoint assumed: POST /users/me/avatar -> { url: string }
+ * Upload avatar image file and return absolute URL along with latest ETag.
+ * Backend endpoint: POST /profiles/me/avatar -> { url: string }
  */
-export async function uploadAvatar(fileUri: string, onProgress?: (progress01: number) => void, signal?: AbortSignal): Promise<string> {
+export async function uploadAvatar(
+  fileUri: string,
+  etag?: string,
+  onProgress?: (progress01: number) => void,
+  signal?: AbortSignal
+): Promise<{ url: string; etag?: string }> {
   const form = new FormData();
   const name = fileUri.split('/').pop() || 'avatar.jpg';
   const type = name.toLowerCase().endsWith('.png') ? 'image/png' : 'image/jpeg';
@@ -44,17 +59,29 @@ export async function uploadAvatar(fileUri: string, onProgress?: (progress01: nu
   // @ts-ignore RN FormData file shape
   form.append('file', { uri: fileUri, name, type });
 
-  const { data } = await api.post('/users/me/avatar', form, {
+  const { data, headers } = await api.post('/profiles/me/avatar', form, {
     headers: {
       'Content-Type': 'multipart/form-data',
       'Cache-Control': 'no-store',
+      ...(etag ? { 'If-Match': etag } : {}),
     },
     onUploadProgress: (evt) => {
       if (onProgress && evt.total) onProgress(evt.loaded / evt.total);
     },
     signal,
   });
-  if (typeof data?.url === 'string') return data.url as string;
-  if (typeof data?.avatarUrl === 'string') return data.avatarUrl as string;
+  const url = typeof data?.url === 'string' ? (data.url as string) : (data?.avatarUrl as string | undefined);
+  if (url) return { url, etag: headers['etag'] };
   throw new Error('Upload failed');
+}
+
+/** Delete current avatar image. */
+export async function deleteAvatar(etag?: string): Promise<{ etag?: string }> {
+  const { headers } = await api.delete('/profiles/me/avatar', {
+    headers: {
+      'Cache-Control': 'no-store',
+      ...(etag ? { 'If-Match': etag } : {}),
+    },
+  });
+  return { etag: headers['etag'] };
 }


### PR DESCRIPTION
## Summary
- switch user APIs to `/profiles/me`
- expose ETag from profile fetch and use `If-Match` for profile updates and avatar operations
- support uploading and deleting avatars with new endpoints

## Testing
- `npm test` *(fails: Playwright tests executed under Jest and offlineJoinLeave.e2e.test.tsx TypeError)*
- `npm run lint` *(fails: ESLint couldn't find config "expo")*

------
https://chatgpt.com/codex/tasks/task_e_68af840d274883208d0ac23f64da3bca