### PR TITLE
Add RSVP and admin game actions

### DIFF
--- a/src/features/games/api.ts
+++ b/src/features/games/api.ts
@@ -1,5 +1,5 @@
 import { api } from '@/src/api/client';
-import type { CreateGameInput, Game } from './types';
+import type { CreateGameInput, Game, Participant } from './types';
 
 export async function fetchGames(): Promise<Game[]> {
   const { data } = await api.get('/games', { headers: { 'Cache-Control': 'no-store' } });
@@ -50,7 +50,48 @@ export async function joinGame(id: string): Promise<void> {
 }
 
 export async function leaveGame(id: string): Promise<void> {
-  await api.post(`/games/${id}/leave`, null, { headers: { 'Cache-Control': 'no-store' } });
+  await api.delete(`/games/${id}/leave`, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function rsvpGame(id: string): Promise<void> {
+  await api.post(`/games/${id}/rsvp`, null, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function unrsvpGame(id: string): Promise<void> {
+  await api.delete(`/games/${id}/unrsvp`, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function holdGame(id: string): Promise<void> {
+  await api.post(`/games/${id}/hold`, null, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function confirmGame(id: string): Promise<void> {
+  await api.post(`/games/${id}/confirm`, null, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function fetchWaitlist(id: string): Promise<Participant[]> {
+  const { data } = await api.get(`/games/${id}/waitlist`, { headers: { 'Cache-Control': 'no-store' } });
+  return Array.isArray(data) ? (data as Participant[]) : [];
+}
+
+export async function promoteFromWaitlist(gameId: string, userId: string): Promise<void> {
+  await api.post(`/games/${gameId}/waitlist/${userId}/promote`, null, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function lockGame(id: string): Promise<void> {
+  await api.post(`/games/admin/${id}/lock`, null, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function unlockGame(id: string): Promise<void> {
+  await api.delete(`/games/admin/${id}/lock`, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function addCohost(gameId: string, userId: string): Promise<void> {
+  await api.post(`/games/admin/${gameId}/cohosts/${userId}`, null, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function removeCohost(gameId: string, userId: string): Promise<void> {
+  await api.delete(`/games/admin/${gameId}/cohosts/${userId}`, { headers: { 'Cache-Control': 'no-store' } });
 }
 
 export async function createGame(input: CreateGameInput): Promise<Game> {

--- a/src/features/games/hooks/useAddCohost.ts
+++ b/src/features/games/hooks/useAddCohost.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { addCohost } from '../api';
+
+export function useAddCohost(gameId: string | undefined) {
+  return useMutation({
+    mutationFn: (userId: string) => addCohost(gameId as string, userId),
+  });
+}
+

--- a/src/features/games/hooks/useConfirmGame.ts
+++ b/src/features/games/hooks/useConfirmGame.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { confirmGame } from '../api';
+
+export function useConfirmGame(id: string | undefined) {
+  return useMutation({
+    mutationFn: () => confirmGame(id as string),
+  });
+}
+

--- a/src/features/games/hooks/useHoldGame.ts
+++ b/src/features/games/hooks/useHoldGame.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { holdGame } from '../api';
+
+export function useHoldGame(id: string | undefined) {
+  return useMutation({
+    mutationFn: () => holdGame(id as string),
+  });
+}
+

--- a/src/features/games/hooks/useLockGame.ts
+++ b/src/features/games/hooks/useLockGame.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { lockGame } from '../api';
+
+export function useLockGame(id: string | undefined) {
+  return useMutation({
+    mutationFn: () => lockGame(id as string),
+  });
+}
+

--- a/src/features/games/hooks/usePromoteFromWaitlist.ts
+++ b/src/features/games/hooks/usePromoteFromWaitlist.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { promoteFromWaitlist } from '../api';
+
+export function usePromoteFromWaitlist(gameId: string | undefined) {
+  return useMutation({
+    mutationFn: (userId: string) => promoteFromWaitlist(gameId as string, userId),
+  });
+}
+

--- a/src/features/games/hooks/useRemoveCohost.ts
+++ b/src/features/games/hooks/useRemoveCohost.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { removeCohost } from '../api';
+
+export function useRemoveCohost(gameId: string | undefined) {
+  return useMutation({
+    mutationFn: (userId: string) => removeCohost(gameId as string, userId),
+  });
+}
+

--- a/src/features/games/hooks/useRsvpGame.ts
+++ b/src/features/games/hooks/useRsvpGame.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { rsvpGame } from '../api';
+
+export function useRsvpGame(id: string | undefined) {
+  return useMutation({
+    mutationFn: () => rsvpGame(id as string),
+  });
+}
+

--- a/src/features/games/hooks/useUnlockGame.ts
+++ b/src/features/games/hooks/useUnlockGame.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { unlockGame } from '../api';
+
+export function useUnlockGame(id: string | undefined) {
+  return useMutation({
+    mutationFn: () => unlockGame(id as string),
+  });
+}
+

--- a/src/features/games/hooks/useUnrsvpGame.ts
+++ b/src/features/games/hooks/useUnrsvpGame.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { unrsvpGame } from '../api';
+
+export function useUnrsvpGame(id: string | undefined) {
+  return useMutation({
+    mutationFn: () => unrsvpGame(id as string),
+  });
+}
+

--- a/src/features/games/hooks/useWaitlist.ts
+++ b/src/features/games/hooks/useWaitlist.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import type { Participant } from '../types';
+import { fetchWaitlist } from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
+
+export function useWaitlist(gameId: string | undefined) {
+  return useQuery<Participant[], unknown>({
+    queryKey: ['game', gameId, 'waitlist'],
+    queryFn: () => fetchWaitlist(gameId as string),
+    enabled: !!gameId,
+    retry: (failureCount: number, error: unknown) => queryRetry(failureCount, error as any),
+  });
+}
+


### PR DESCRIPTION
## Summary
- switch leaveGame API to DELETE
- add RSVP, waitlist, and admin management endpoints
- expose React Query hooks for new game actions

## Testing
- `npm test` *(fails: Playwright tests executed during Jest run)*
- `npm run lint` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68af840e29748320b95896b369376055