### PR TITLE
feat: add chat and notification features

### DIFF
--- a/src/features/chat/api.ts
+++ b/src/features/chat/api.ts
@@ -1,0 +1,21 @@
+import { api } from '@/src/api/client';
+
+export type ChatMessage = {
+  id: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+};
+
+export async function fetchChat(gameId: string): Promise<ChatMessage[]> {
+  const { data } = await api.get(`/games/${gameId}/chat`, { headers: { 'Cache-Control': 'no-store' } });
+  return data as ChatMessage[];
+}
+
+export async function markChatRead(gameId: string, messageId: string): Promise<void> {
+  await api.post(
+    '/chat/read',
+    { gameId, messageId },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/src/features/chat/components/ChatList.tsx
+++ b/src/features/chat/components/ChatList.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import { ActivityIndicator, FlatList } from 'react-native';
+import { Text, View } from '@/components/Themed';
+import { useChat } from '../hooks/useChat';
+import { useChatRead } from '../hooks/useChatRead';
+
+type Props = { gameId: string };
+
+export function ChatList({ gameId }: Props) {
+  const { data, isLoading, refetch } = useChat(gameId);
+  const markRead = useChatRead(gameId);
+
+  useEffect(() => {
+    if (data && data.length > 0) {
+      const last = data[data.length - 1];
+      markRead.mutate(last.id);
+    }
+  }, [data, markRead]);
+
+  if (isLoading) return <ActivityIndicator />;
+
+  return (
+    <FlatList
+      data={data ?? []}
+      keyExtractor={(item) => item.id}
+      refreshing={isLoading}
+      onRefresh={refetch}
+      renderItem={({ item }) => (
+        <View style={{ padding: 8 }}>
+          <Text style={{ fontWeight: 'bold' }}>{item.userId}</Text>
+          <Text>{item.content}</Text>
+        </View>
+      )}
+    />
+  );
+}

--- a/src/features/chat/hooks/useChat.ts
+++ b/src/features/chat/hooks/useChat.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchChat, ChatMessage } from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
+
+export function useChat(gameId: string) {
+  return useQuery<ChatMessage[], unknown>({
+    queryKey: ['chat', gameId],
+    queryFn: () => fetchChat(gameId),
+    enabled: !!gameId,
+    retry: (failureCount, error: unknown) => queryRetry(failureCount, error as any),
+  });
+}

--- a/src/features/chat/hooks/useChatRead.ts
+++ b/src/features/chat/hooks/useChatRead.ts
@@ -1,0 +1,12 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { markChatRead } from '../api';
+
+export function useChatRead(gameId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (messageId: string) => markChatRead(gameId, messageId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['chat', gameId] });
+    },
+  });
+}

--- a/src/features/notifications/api.ts
+++ b/src/features/notifications/api.ts
@@ -1,0 +1,25 @@
+import { api } from '@/src/api/client';
+
+export type Notification = {
+  id: string;
+  message: string;
+  read: boolean;
+  createdAt: string;
+};
+
+export async function fetchNotifications(): Promise<Notification[]> {
+  const { data } = await api.get('/notifications', { headers: { 'Cache-Control': 'no-store' } });
+  return data as Notification[];
+}
+
+export async function markNotificationRead(id: string): Promise<void> {
+  await api.put(`/notifications/${id}/read`, null, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function subscribeToPushNotifications(token: string): Promise<void> {
+  await api.post('/notifications/subscribe', { token }, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function unsubscribeFromPushNotifications(token: string): Promise<void> {
+  await api.post('/notifications/unsubscribe', { token }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/features/notifications/components/NotificationBadge.tsx
+++ b/src/features/notifications/components/NotificationBadge.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Text, View } from '@/components/Themed';
+import { useNotifications } from '../hooks/useNotifications';
+
+export function NotificationBadge() {
+  const { data } = useNotifications();
+  const count = (data ?? []).filter((n) => !n.read).length;
+  if (count === 0) return null;
+  return (
+    <View style={{ backgroundColor: 'red', borderRadius: 10, paddingHorizontal: 6, paddingVertical: 2 }}>
+      <Text style={{ color: 'white', fontSize: 12 }}>{count}</Text>
+    </View>
+  );
+}

--- a/src/features/notifications/hooks/useMarkNotificationRead.ts
+++ b/src/features/notifications/hooks/useMarkNotificationRead.ts
@@ -1,0 +1,12 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { markNotificationRead } from '../api';
+
+export function useMarkNotificationRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => markNotificationRead(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchNotifications, Notification } from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
+
+export function useNotifications() {
+  return useQuery<Notification[], unknown>({
+    queryKey: ['notifications'],
+    queryFn: fetchNotifications,
+    retry: (failureCount, error: unknown) => queryRetry(failureCount, error as any),
+  });
+}

--- a/src/features/notifications/hooks/usePushNotifications.ts
+++ b/src/features/notifications/hooks/usePushNotifications.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+  subscribeToPushNotifications,
+  unsubscribeFromPushNotifications,
+} from '../api';
+
+export function usePushNotifications() {
+  const subscribe = useMutation({
+    mutationFn: (token: string) => subscribeToPushNotifications(token),
+  });
+  const unsubscribe = useMutation({
+    mutationFn: (token: string) => unsubscribeFromPushNotifications(token),
+  });
+  return { subscribe, unsubscribe };
+}


### PR DESCRIPTION
## Summary
- add API modules for chat and notifications
- provide React Query hooks for chat history, read cursors, notification fetch, push subscription
- create ChatList and NotificationBadge components using hooks

## Testing
- `npm test` (fails: Playwright test in Jest and offline join/leave)
- `npm run lint` (fails: package not in lockfile)


------
https://chatgpt.com/codex/tasks/task_e_68af840f71a8832082bbb00d63950d2a