### PR TITLE
Add ratings, stats, and admin APIs with UI

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -79,6 +79,13 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="stats"
+        options={{
+          title: 'Stats',
+          tabBarIcon: ({ color }) => <TabBarIcon name="bar-chart" color={color} />,
+        }}
+      />
+      <Tabs.Screen
         name="about"
         options={{
           title: 'About',

--- a/app/(tabs)/game/[id].tsx
+++ b/app/(tabs)/game/[id].tsx
@@ -407,6 +407,12 @@ export default function GameDetailsScreen() {
         disabled={join.isPending || leave.isPending || !online || (isFull && !joined)}
       />
 
+      <View style={{ height: 16 }} />
+      <Button
+        title="Rate game"
+        onPress={() => router.push(`/(tabs)/game/${id}/rate`)}
+      />
+
       {isOwner ? (
         <>
           <View style={{ height: 16 }} />

--- a/app/(tabs)/game/[id]/rate.tsx
+++ b/app/(tabs)/game/[id]/rate.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useSubmitRating } from '@/src/features/ratings/hooks/useSubmitRating';
+
+export default function RateGameScreen() {
+  const { id } = useLocalSearchParams<{ id?: string }>();
+  const router = useRouter();
+  const mutation = useSubmitRating(id as string);
+  const [rating, setRating] = useState('');
+  const [comment, setComment] = useState('');
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Stack.Screen options={{ title: 'Rate Game' }} />
+      <Text>Rating (1-5)</Text>
+      <TextInput
+        accessibilityLabel="Rating"
+        keyboardType="numeric"
+        value={rating}
+        onChangeText={setRating}
+        style={{ borderWidth: 1, padding: 8, marginBottom: 12 }}
+      />
+      <Text>Comment</Text>
+      <TextInput
+        accessibilityLabel="Comment"
+        value={comment}
+        onChangeText={setComment}
+        style={{ borderWidth: 1, padding: 8, marginBottom: 12 }}
+      />
+      <Button
+        title={mutation.isPending ? 'Submitting...' : 'Submit'}
+        onPress={() => {
+          const value = parseInt(rating, 10);
+          if (!Number.isFinite(value)) return;
+          mutation.mutate(
+            { rating: value, comment },
+            { onSuccess: () => router.back() }
+          );
+        }}
+        disabled={mutation.isPending}
+      />
+    </View>
+  );
+}

--- a/app/(tabs)/stats.tsx
+++ b/app/(tabs)/stats.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, ActivityIndicator } from 'react-native';
+import { Text } from '@/components/Themed';
+import { Stack } from 'expo-router';
+import { useStats } from '@/src/features/stats/hooks/useStats';
+
+export default function StatsScreen() {
+  const { data, isLoading, isError } = useStats();
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Stack.Screen options={{ title: 'Stats' }} />
+      {isLoading && <ActivityIndicator />} 
+      {isError && <Text>Failed to load stats</Text>}
+      {data &&
+        Object.entries(data).map(([key, value]) => (
+          <Text key={key} style={{ marginBottom: 8 }}>{`${key}: ${value}`}</Text>
+        ))}
+    </View>
+  );
+}

--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -1,0 +1,16 @@
+import { Stack, useRouter } from 'expo-router';
+import { useEffect } from 'react';
+import { useAuthStore } from '@/src/stores/auth';
+
+export default function AdminLayout() {
+  const user = useAuthStore((s) => s.user);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user?.roles?.includes('admin')) {
+      router.replace('/(tabs)');
+    }
+  }, [user, router]);
+
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, FlatList } from 'react-native';
+import { Text } from '@/components/Themed';
+import { Stack } from 'expo-router';
+import { useAuditLogs } from '@/src/features/admin/hooks/useAuditLogs';
+import { useProfanityWords } from '@/src/features/admin/hooks/useProfanityWords';
+
+export default function AdminDashboard() {
+  const { data: logs } = useAuditLogs();
+  const profanity = useProfanityWords();
+  const [newWord, setNewWord] = useState('');
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Stack.Screen options={{ title: 'Admin' }} />
+      <Text style={{ fontWeight: 'bold', marginBottom: 8 }}>Audit Logs</Text>
+      <FlatList
+        data={logs ?? []}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Text>{`${item.timestamp} - ${item.actor ?? 'system'} - ${item.action}`}</Text>
+        )}
+        style={{ marginBottom: 16 }}
+      />
+
+      <Text style={{ fontWeight: 'bold', marginBottom: 8 }}>Profanity Words</Text>
+      <FlatList
+        data={profanity.data ?? []}
+        keyExtractor={(item) => item}
+        renderItem={({ item }) => (
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text style={{ flex: 1 }}>{item}</Text>
+            <Button title="Delete" onPress={() => profanity.remove.mutate(item)} />
+          </View>
+        )}
+      />
+      <View style={{ flexDirection: 'row', marginTop: 8 }}>
+        <TextInput
+          accessibilityLabel="New word"
+          value={newWord}
+          onChangeText={setNewWord}
+          style={{ flex: 1, borderWidth: 1, padding: 8, marginRight: 8 }}
+        />
+        <Button
+          title="Add"
+          onPress={() => {
+            if (!newWord.trim()) return;
+            profanity.add.mutate(newWord.trim(), { onSuccess: () => setNewWord('') });
+          }}
+        />
+      </View>
+    </View>
+  );
+}

--- a/src/features/admin/api.ts
+++ b/src/features/admin/api.ts
@@ -1,0 +1,35 @@
+import { api } from '@/src/api/client';
+
+export type AuditLog = {
+  id: string;
+  action: string;
+  timestamp: string;
+  actor?: string;
+};
+
+export async function fetchAuditLogs(): Promise<AuditLog[]> {
+  const { data } = await api.get('/admin/audit-logs', { headers: { 'Cache-Control': 'no-store' } });
+  if (Array.isArray(data)) return data as AuditLog[];
+  return (data?.items ?? []) as AuditLog[];
+}
+
+export async function fetchProfanityWords(): Promise<string[]> {
+  const { data } = await api.get('/admin/profanity', { headers: { 'Cache-Control': 'no-store' } });
+  if (Array.isArray(data)) return data as string[];
+  if (Array.isArray(data?.words)) return data.words as string[];
+  return [];
+}
+
+export async function addProfanityWord(word: string): Promise<void> {
+  await api.post('/admin/profanity', { word }, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function updateProfanityWord(oldWord: string, newWord: string): Promise<void> {
+  await api.put(`/admin/profanity/${encodeURIComponent(oldWord)}`, { word: newWord }, {
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}
+
+export async function deleteProfanityWord(word: string): Promise<void> {
+  await api.delete(`/admin/profanity/${encodeURIComponent(word)}`, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/features/admin/hooks/useAuditLogs.ts
+++ b/src/features/admin/hooks/useAuditLogs.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAuditLogs, AuditLog } from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
+
+export function useAuditLogs() {
+  return useQuery<AuditLog[], unknown>({
+    queryKey: ['admin', 'auditLogs'],
+    queryFn: fetchAuditLogs,
+    retry: (failureCount, error) => queryRetry(failureCount, error as any),
+  });
+}

--- a/src/features/admin/hooks/useProfanityWords.ts
+++ b/src/features/admin/hooks/useProfanityWords.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchProfanityWords,
+  addProfanityWord,
+  updateProfanityWord,
+  deleteProfanityWord,
+} from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
+import { useToast } from '@/src/components/ToastProvider';
+
+export function useProfanityWords() {
+  const qc = useQueryClient();
+  const toast = useToast();
+
+  const list = useQuery<string[], unknown>({
+    queryKey: ['admin', 'profanity'],
+    queryFn: fetchProfanityWords,
+    retry: (failureCount, error) => queryRetry(failureCount, error as any),
+  });
+
+  const add = useMutation({
+    mutationFn: (word: string) => addProfanityWord(word),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['admin', 'profanity'] });
+      toast.success('Word added');
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Add failed'),
+  });
+
+  const update = useMutation({
+    mutationFn: ({ oldWord, newWord }: { oldWord: string; newWord: string }) =>
+      updateProfanityWord(oldWord, newWord),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['admin', 'profanity'] });
+      toast.success('Word updated');
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Update failed'),
+  });
+
+  const remove = useMutation({
+    mutationFn: (word: string) => deleteProfanityWord(word),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['admin', 'profanity'] });
+      toast.info('Word deleted');
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Delete failed'),
+  });
+
+  return { ...list, add, update, remove };
+}

--- a/src/features/ratings/api.ts
+++ b/src/features/ratings/api.ts
@@ -1,0 +1,11 @@
+import { api } from '@/src/api/client';
+
+export type RatingInput = { rating: number; comment?: string };
+
+/**
+ * Submit a rating for a game.
+ * Backend endpoint assumed: POST /games/:id/ratings
+ */
+export async function submitRating(gameId: string, input: RatingInput): Promise<void> {
+  await api.post(`/games/${gameId}/ratings`, input, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/features/ratings/hooks/useSubmitRating.ts
+++ b/src/features/ratings/hooks/useSubmitRating.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { submitRating, RatingInput } from '../api';
+import { useToast } from '@/src/components/ToastProvider';
+
+export function useSubmitRating(gameId: string) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: (input: RatingInput) => submitRating(gameId, input),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['game', gameId] });
+      toast.success('Rating submitted');
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Rating failed'),
+  });
+}

--- a/src/features/stats/api.ts
+++ b/src/features/stats/api.ts
@@ -1,0 +1,9 @@
+import { api } from '@/src/api/client';
+
+export type Stats = Record<string, number>;
+
+/** Fetch aggregate statistics. */
+export async function fetchStats(): Promise<Stats> {
+  const { data } = await api.get('/stats', { headers: { 'Cache-Control': 'no-store' } });
+  return (data ?? {}) as Stats;
+}

--- a/src/features/stats/hooks/useStats.ts
+++ b/src/features/stats/hooks/useStats.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchStats, Stats } from '../api';
+import { queryRetry } from '@/src/utils/queryRetry';
+
+export function useStats() {
+  return useQuery<Stats, unknown>({
+    queryKey: ['stats'],
+    queryFn: fetchStats,
+    retry: (failureCount, error) => queryRetry(failureCount, error as any),
+  });
+}


### PR DESCRIPTION
## Summary
- add rating API/hooks and rating screen
- expose stats endpoint with tab screen
- add admin APIs and dashboard with profanity and audit logs
- gate admin routes by role

## Testing
- `npm test` *(fails: Playwright specs executed; offline e2e failing: onOnline is not a function)*
- `npm test __tests__` *(fails: offline join/leave e2e test missing onOnline)*

------
https://chatgpt.com/codex/tasks/task_e_68af8410e9ac8320aa63c0478a3d1592